### PR TITLE
remove unnecessary/outdated references

### DIFF
--- a/docs/Audio and Video Streaming Setup/index.md
+++ b/docs/Audio and Video Streaming Setup/index.md
@@ -94,16 +94,6 @@ Using pipe streaming may require a modification to the SDL HMI.
 
 #### VIDEO
 
-##### RTP
-Comment out the following lines in `ffw/NavigationRPC.js`:
-```
-//  if (request.params.config.protocol != 'RAW') {
-//    Em.Logger.log('FFW.' + request.method + ' rejects protocol: '
-//                  + request.params.config.protocol);
-//    rejectedParams.push('protocol');
-//  }
-```
-
 ### Video Stream Pipe
 
 After you start SDL Core, cd into the bin/storage directory and there should be a file named "video_stream_pipe". Use the gst-launch command that worked for your environment and set file source to the video_stream_pipe file. You should see “setting pipeline to PAUSED” and “Pipeline is PREROLLING”.
@@ -154,16 +144,6 @@ Using socket streaming may require a modification to the SDL HMI.
 Comment out the following lines in `app/model/sdl/Abstract/Model.js`:
 ```
 //  SDL.SDLModel.playVideo(appID);
-```
-
-##### RTP
-Comment out the following lines in `ffw/NavigationRPC.js`:
-```
-//  if (request.params.config.protocol != 'RAW') {
-//    Em.Logger.log('FFW.' + request.method + ' rejects protocol: '
-//                  + request.params.config.protocol);
-//    rejectedParams.push('protocol');
-//  }
 ```
 
 #### AUDIO

--- a/docs/Audio and Video Streaming Setup/index.md
+++ b/docs/Audio and Video Streaming Setup/index.md
@@ -193,10 +193,6 @@ chromium-browser index.html
 
 ### Start Video or Audio Stream
 
-!!! NOTE
-No public mobile application currently exists that implements video streaming.
-!!!
-
 [iOS Video Streaming Guide](../../iOS/mobile-navigation/video-streaming/)
 
 [Android Video Streaming Guide](../../Android/mobile-navigation/video-streaming/)

--- a/docs/Audio and Video Streaming Setup/index.md
+++ b/docs/Audio and Video Streaming Setup/index.md
@@ -193,6 +193,10 @@ chromium-browser index.html
 
 ### Start Video or Audio Stream
 
+!!! NOTE
+No open source mobile application currently implements video streaming.
+!!!
+
 [iOS Video Streaming Guide](../../iOS/mobile-navigation/video-streaming/)
 
 [Android Video Streaming Guide](../../Android/mobile-navigation/video-streaming/)

--- a/docs/Audio and Video Streaming Setup/index.md
+++ b/docs/Audio and Video Streaming Setup/index.md
@@ -116,10 +116,6 @@ gst-launch-1.0 filesrc location=$SDL_BUILD_PATH/bin/storage/video_stream_pipe ! 
 gst-launch-1.0 filesrc location=$SDL_BUILD_PATH/bin/storage/audio_stream_pipe ! audio/x-raw,format=S16LE,rate=16000,channels=1 ! pulsesink
 ```
 
-!!! NOTE
-Currently there is a [known issue](https://github.com/smartdevicelink/sdl_core/issues/2633) with audio pipe streaming where the audio will cut off before all of the data has been played.
-!!!
-
 ## Socket Streaming
 
 ### Configuration (smartDeviceLink.ini)


### PR DESCRIPTION
[SDL HMI PR #250](https://github.com/smartdevicelink/sdl_hmi/pull/250) removed some code referenced by the Audio/Video streaming core guide. Part of this change removes the references to code that no longer exists. Now it takes less manual setup to get started with RTP streaming.

Next, a note at the end of the audio/video streaming guide stating `No public mobile application currently exists that implements video streaming.` has been rewritten for clarity. It now states `No open source mobile application currently implements video streaming.`

Additionally, I removed the line about the known issue with pipe streaming not playing the entire audio clip as this was fixed with [SDL Core PR #2956](https://github.com/smartdevicelink/sdl_core/pull/2956).