### PR TITLE
Add automake package

### DIFF
--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -9,7 +9,7 @@ The dependencies for SDL Core vary based on the configuration. You can change SD
 The default dependencies for SDL Core can be installed with the following command:
 
 ```bash
-sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl1.0-dev libssl1.0.0 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools automake
+sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl1.0-dev libssl1.0.0 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools automake libexpat1-dev
 ```
 
 ### Initialize Submodules

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -9,7 +9,7 @@ The dependencies for SDL Core vary based on the configuration. You can change SD
 The default dependencies for SDL Core can be installed with the following command:
 
 ```bash
-sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl1.0-dev libssl1.0.0 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools
+sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl1.0-dev libssl1.0.0 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools automake
 ```
 
 ### Initialize Submodules


### PR DESCRIPTION
Update **docs/Getting Started/Install and Run/index.md**
 - Add **automake** package
without this package command `make install-3rd_party` is failed with the next errors:
```
/sdl_build/src/3rd_party/bson_c_lib/missing: line 81: aclocal-1.15: command not found
WARNING: 'aclocal-1.15' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <http://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <http://www.gnu.org/software/autoconf>
         <http://www.gnu.org/software/m4/>
         <http://www.perl.org/>
Makefile:401: recipe for target 'aclocal.m4' failed
```
- Add **libexpat** 
without this dynamic library SDL doesn't pass our Smoke tests.
```
./smartDeviceLinkCore: error while loading shared libraries: libexpat.so: cannot open shared object file: No such file or directory
```