### PR TITLE
Update default environment to Ubuntu 20.04

### DIFF
--- a/docs/FAQ/index.md
+++ b/docs/FAQ/index.md
@@ -3,7 +3,7 @@
 Here are a few of the most common questions new developers have around the SDL Core project. 
 
 ## What OS should I use to get started?
-Currently the SDL Core repo is built for Ubuntu 18.04 as our default environment.
+Currently the SDL Core repo is built for Ubuntu 20.04 as our default environment.
 
 ## I'm getting a lot of compilation errors, how do I get past them?
 The most common errors come from dependencies issues. Ensure your system has all the required packages to compile the project. Try running the commands in the [dependencies section](../getting-started/install-and-run/#dependencies) of the Getting Started guide.

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -1,5 +1,5 @@
 # Installation
-A quick guide to installing, configuring, and running an instance of SDL Core on a Linux OS (default environment is Ubuntu 18.04 LTS).
+A quick guide to installing, configuring, and running an instance of SDL Core on a Linux OS (default environment is Ubuntu 20.04 LTS).
 
 ## Dependencies
 The dependencies for SDL Core vary based on the configuration. You can change SDL Core's build configuration in the top level CMakeLists.txt. We have defaulted this file to a configuration which we believe is common for people who are interested in getting up and running quickly, generally on a Linux VM.
@@ -7,7 +7,7 @@ The dependencies for SDL Core vary based on the configuration. You can change SD
 The default dependencies for SDL Core can be installed with the following command:
 
 ```bash
-sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl1.0-dev libssl1.0.0 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools
+sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl-dev libssl1.1 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools python
 ```
 
 ### Clone SDL Core and Submodules


### PR DESCRIPTION
Documentation updates for https://github.com/smartdevicelink/sdl_core/issues/3606.
Updates default environment to Ubuntu 20.04 and updates dependencies list accordingly.