### PR TITLE
SDL Core 8.0.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -87,6 +87,9 @@
                 },
                 {
                     "name": "Migrating SDL Core 7.0 to 7.1"
+                },
+                {
+                    "name": "Migrating SDL Core 7.1 to 8.0"
                 }
             ]
         },

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -147,7 +147,7 @@ The following steps can be used to build the develop branch of SDL Core from scr
 The following commands only need to be run on the first installation of the project
 
 ```
-sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl-dev libssl1.1 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools python
+sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl-dev libssl1.1 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools python3-wheel python
 git clone https://github.com/smartdevicelink/sdl_core
 ```
 
@@ -169,5 +169,6 @@ mkdir sdl_build
 cd sdl_build
 cmake ../sdl_core -DEXTENDED_POLICY=EXTERNAL_PROPRIETARY
 make install-3rd_party
+make install_python_dependencies
 make -j3 install
 ```

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -49,7 +49,9 @@ CMake is used to configure your SDL Core build before you compile the project, t
 #### Development/Debug Options
 |Option|Value(s)|Dependencies|Description|
 |:-----|:-------|:-----------|:----------|
-|ENABLE_LOG|**ON**/OFF|log4cxx (included in project)|Enable/Disable logging tool. Logs are stored in `<sdl_build_dir>/bin/SmartDeviceLinkCore.log` and can be configured by `log4cxx.properties` in the same folder.|
+|ENABLE_LOG|**ON**/OFF|log4cxx (included in project)/boost logger|Enable/Disable logging tool. Logs are stored in `<sdl_build_dir>/bin/SmartDeviceLinkCore.log`.|
+|LOGGER_NAME|**LOG4CXX**|log4cxx (included in project)|Build with the apache log4cxx logger. Log properties can be configured in `<sdl_build_dir>/bin/log4cxx.properties`|
+|LOGGER_NAME|BOOST|boost logger|Build with the boost logger library. Log properties can be configured in `<sdl_build_dir>/bin/boostlogconfig.ini`|
 |BUILD_TESTS|ON/**OFF**|GTest (packages: libgtest-dev)|Build unit tests (run with `make test`)|
 |USE_COTIRE|**ON**/OFF|N/A|Option to use [cotire](https://github.com/sakra/cotire) to speed up the build process when BUILD_TESTS is ON.|
 |USE_GOLD_LD|**ON**/OFF|N/A|Option to use gold linker in place of gnu ld to speed up the build process.|

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -44,7 +44,6 @@ CMake is used to configure your SDL Core build before you compile the project, t
 |EXTENDED_POLICY|HTTP|N/A|HTTP (simplified) Policy flow. `OnSystemRequest` is sent with HTTP RequestType to initiate a policy table update. The HMI is not involved in the PTU process in this mode, meaning that policy table encryption is not supported.|
 |EXTENDED_POLICY|**PROPRIETARY**|N/A|Default Policy flow, PROPRIETARY RequestType. Simplified policy feature set (no user consent, encryption/decryption only available via HMI)|
 |EXTENDED_POLICY|EXTERNAL_PROPRIETARY|packages: python-pip, python-dev (If using the included sample policy manager, which is automatically started by `core.sh` by default)|Full Policy flow, PROPRIETARY RequestType. Full-featured policies, along with support for handling encryption/decryption via external application|
-|ENABLE_HMI_PTU_DECRYPTION|**ON**/OFF|N/A|Only applies to PROPRIETARY mode. When enabled, the HMI is expected to decrypt the policy table before sending `SDL.OnReceivedPolicyUpdate`.|
 
 #### Development/Debug Options
 |Option|Value(s)|Dependencies|Description|
@@ -71,7 +70,7 @@ cd ../sdl_build
 From the build folder you created, run `cmake {path_to_sdl_core_source_folder}`  with any flags that you want to change in the format of `-D<option-name>=<value>`, for example:
 
 ```bash
-cmake -DENABLE_HMI_PTU_DECRYPTION=OFF ../sdl_core
+cmake ../sdl_core
 ```
 
 From there, you can build and install the project, run the following commands in your build folder:

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -7,7 +7,7 @@ The dependencies for SDL Core vary based on the configuration. You can change SD
 The default dependencies for SDL Core can be installed with the following command:
 
 ```bash
-sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl-dev libssl1.1 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools python
+sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl-dev libssl1.1 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools python3-wheel python
 ```
 
 ### Clone SDL Core and Submodules
@@ -78,6 +78,7 @@ From there, you can build and install the project, run the following commands in
 
 ```bash
 make install-3rd_party
+make install_python_dependencies
 make install
 ```
 

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -40,7 +40,7 @@ CMake is used to configure your SDL Core build before you compile the project, t
 |Option|Value(s)|Dependencies|Description|
 |:-----|:-------|:-----------|:----------|
 |EXTENDED_MEDIA_MODE|ON/**OFF**|GStreamer, PulseAudio (packages: libpulse-dev)|Enable/Disable audio pass thru via PulseAudio mic recording. When this option is disabled, Core will emulate audio pass thru by sending a looped audio file.|
-|ENABLE_SECURITY|**ON**/OFF|OpenSSL (packages: libssl1.0-dev)|Enable/Disable support for secured SDL protocol services|
+|ENABLE_SECURITY|**ON**/OFF|OpenSSL (packages: libssl-dev)|Enable/Disable support for secured SDL protocol services|
 |EXTENDED_POLICY|HTTP|N/A|HTTP (simplified) Policy flow. `OnSystemRequest` is sent with HTTP RequestType to initiate a policy table update. The HMI is not involved in the PTU process in this mode, meaning that policy table encryption is not supported.|
 |EXTENDED_POLICY|**PROPRIETARY**|N/A|Default Policy flow, PROPRIETARY RequestType. Simplified policy feature set (no user consent, encryption/decryption only available via HMI)|
 |EXTENDED_POLICY|EXTERNAL_PROPRIETARY|packages: python-pip, python-dev (If using the included sample policy manager, which is automatically started by `core.sh` by default)|Full Policy flow, PROPRIETARY RequestType. Full-featured policies, along with support for handling encryption/decryption via external application|

--- a/docs/Getting Started/Install and Run/index.md
+++ b/docs/Getting Started/Install and Run/index.md
@@ -60,11 +60,12 @@ CMake is used to configure your SDL Core build before you compile the project, t
 
 After installing the appropriate dependencies for your build configuration, you can run `cmake` with your chosen options. 
 
-Begin by creating a build folder outside of SDL Core source folder, for example:
+Begin by creating a build folder **outside** of SDL Core source folder, for example:
 
 ```bash
-mkdir ../sdl_build
-cd ../sdl_build
+cd ..
+mkdir sdl_build
+cd sdl_build
 ```
 
 From the build folder you created, run `cmake {path_to_sdl_core_source_folder}`  with any flags that you want to change in the format of `-D<option-name>=<value>`, for example:
@@ -128,3 +129,44 @@ If Core was built with `EXTENDED_POLICY=EXTERNAL_PROPRIETARY`, the `core.sh` scr
 ./core.sh <command> false
 ``` 
 !!!
+
+## Example - EXTERNAL_PROPRIETARY build
+
+!!! Note
+To perform a completely clean build after previously building SDL Core, delete the existing build folder before running these steps:
+```
+rm -rf sdl_build
+```
+!!!
+
+The following steps can be used to build the develop branch of SDL Core from scratch with the `EXTERNAL_PROPRIETARY` policy mode enabled:
+
+### First Time Setup
+
+The following commands only need to be run on the first installation of the project
+
+```
+sudo apt-get install git cmake build-essential sqlite3 libsqlite3-dev libssl-dev libssl1.1 libusb-1.0-0-dev libudev-dev libgtest-dev libbluetooth3 libbluetooth-dev bluez-tools libpulse-dev python3-pip python3-setuptools python
+git clone https://github.com/smartdevicelink/sdl_core
+```
+
+### Configuration
+
+```
+cd sdl_core
+git checkout develop
+git pull
+git submodule init
+git submodule update
+```
+
+### Installation
+
+```
+cd ..
+mkdir sdl_build
+cd sdl_build
+cmake ../sdl_core -DEXTENDED_POLICY=EXTERNAL_PROPRIETARY
+make install-3rd_party
+make -j3 install
+```

--- a/docs/Integrating Your HMI/Developing the HMI UI/index.md
+++ b/docs/Integrating Your HMI/Developing the HMI UI/index.md
@@ -120,6 +120,10 @@ The following graphic shows what should happen when the HMI receives a `UI.SetMe
 
 ## Implementing Soft Buttons
 
+!!! NOTE
+As of Core 8.0.0 it is important to include `CUSTOM_BUTTON` in the response to `Buttons.GetCapabilities` so that an app may subscribe to soft buttons.
+!!!
+
 A `Softbutton` received from a `UI.Show` request should be displayed when the app is displaying a template. A template can have a max of 8 `Softbuttons`. These buttons can be of type `TEXT`, `IMAGE`, or `BOTH`.
 
 The following graphic displays how `Softbuttons` in a `UI.Show` request can be displayed:

--- a/docs/Integrating Your HMI/Developing the HMI UI/index.md
+++ b/docs/Integrating Your HMI/Developing the HMI UI/index.md
@@ -93,7 +93,7 @@ If an app wants to clear a text field that it sent in a previous `UI.Show` reque
 
 Apps which use the `MEDIA` template have access to a few specific UI elements that are not available to non-media apps. 
 
-The following buttons can only be subscribed to by media apps and and are generally only available in the `MEDIA` template layout:
+The following buttons can only be subscribed to by media apps and are generally only available in the `MEDIA` template layout:
 
   - `PLAY_PAUSE`
   - `SEEKLEFT`

--- a/docs/Integrating Your HMI/SDL Core and HMI Communication/index.md
+++ b/docs/Integrating Your HMI/SDL Core and HMI Communication/index.md
@@ -288,7 +288,7 @@ An RPC must be sent in result format for its parameters to be passed to mobile.
 | :------------- | :------------- |
 | id      | Required property which must be the same as the value of the associated request object. If there was an error in detecting the id in the request object, this value must be null.  |
 | jsonrpc | Must be exactly **"2.0"**|
-| result | The result property must contain a `method` field which is the same as the corresponding request and a corresponding [result code](https://smartdevicelink.com/en/guides/hmi/common/enums/#result) should be sent in the result property. The result property may also include additional properties as defined in the [HMI API](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/interfaces/HMI_API.xml).|
+| result | The result property must contain a `method` field which is the same as the corresponding request and a corresponding [result code](https://smartdevicelink.com/en/docs/hmi/master/common/enums/#result) should be sent in the result property. The result property may also include additional properties as defined in the [HMI API](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/interfaces/HMI_API.xml).|
 
 ### Example Responses
 #### Response with no Parameters

--- a/docs/Migrating to Newer SDL Versions/Migrating SDL Core 6.1 to 7.0/index.md
+++ b/docs/Migrating to Newer SDL Versions/Migrating SDL Core 6.1 to 7.0/index.md
@@ -217,7 +217,7 @@ Setting these limits does not change the behavior of SDL Core. It is up to the H
 
 ### Webengine Projection Support
 
-A new `WEB_VIEW` `appHMIType` and template layout was added which will allow apps to render a template-independent view in a browser environment with JavaScript and HTML.
+A new `WEB_VIEW` `AppHMIType` and template layout was added which will allow apps to render a template-independent view in a browser environment with JavaScript and HTML.
 
 ```
 <enum name="AppHMIType">
@@ -227,7 +227,7 @@ A new `WEB_VIEW` `appHMIType` and template layout was added which will allow app
 </enum>
 ```
 
-This `appHMIType` must be explicitly specified in an app's policy table entry for SDL Core to allow it to be used.
+This `AppHMIType` must be explicitly specified in an app's policy table entry for SDL Core to allow it to be used.
 
 Policy Table Entry:
 
@@ -235,7 +235,7 @@ Policy Table Entry:
 ...
 "app_policies": {
     "webengine_appID": {
-+       "appHMIType: ["WEB_VIEW"],
++       "AppHMIType": ["WEB_VIEW"],
         "keep_context": false,
         "steal_focus": false,
         "priority": "NONE",

--- a/docs/Migrating to Newer SDL Versions/Migrating SDL Core 7.1 to 8.0/index.md
+++ b/docs/Migrating to Newer SDL Versions/Migrating SDL Core 7.1 to 8.0/index.md
@@ -1,0 +1,146 @@
+# Migrating SDL Core 7.1 to 8.0
+
+## Environment Updates
+
+### Ubuntu Versions
+
+SDL Core 8.0.0 no longer supports Ubuntu 16. Supported versions of SDL Core are Ubuntu 18.04 and Ubuntu 20.04.
+
+### SSL Versions
+
+SDL Core 8.0.0 dropped support for libssl1.0. Developers should install `libssl-dev` instead of `libssl1.0-dev`.
+
+## Updates to CMAKE Build Configuration
+
+### Removed Flag `ENABLE_HMI_PTU_DECRYPTION`
+
+`ENABLE_HMI_PTU_DECRYPTION` was removed from the build configuration. Behaviors defined by ON/OFF options are now both supported without the need for this build flag.
+
+### Boost Logger
+
+The default logger is still using LOG4CXX but the option is now available to use Boost for the logger. When porting SDL Core to different Linux environments, the LOG4CXX logger was known to cause dependency issues. Boost is offered as an alternative logger in hopes of making porting SDL Core to different environments easier.
+
+```
+set(LOGGER_NAME "LOG4CXX" CACHE STRING "Logging library to use (BOOST, LOG4CXX)")
+```
+
+## Updates to Configuration File smartDeviceLink.ini
+
+### DefaultTimeoutCompensation
+
+This parameter was added to the smartDeviceLink.ini configuration to compensate for transfer and processing time of requests. This value is added to the `DefaultTimeout` parameter when calculating the RPC request timeout. Previously, specific requests such as Alert were hardcoded to extend their default timeout, now timeout compensation is configurable and applied to all requests.
+
+```
+; Extra time to compensate default timeout due to external delays
+DefaultTimeoutCompensation = 1000
+```
+
+### Icons Storage Folder
+
+The default parameter `AppIconsFolder` was updated to use a directory named “icons”. This value used to be “storage”.
+
+```
+; Specify a dedicated folder, as old files in this folder can be automatically removed
+AppIconsFolder = icons
+```
+
+## HMI Behavior Changes
+
+### Avoid Custom Button Subscription in Case HMI Incompatibility
+
+SDL Core 8.0.0 no longer automatically subscribes to `CUSTOM_BUTTON`. If an HMI supports soft buttons, it must include an entry for `CUSTOM_BUTTON` in its button capabilities in order for mobile to receive `OnButtonPress` and `OnButtonEvent` notifications.
+
+### OnEventChanged (PHONE_CALL)
+
+The behavior of the `PHONE_CALL` event was changed to only affect the `audioStreamingState` of an app. Rather than automatically deactivating the active app, SDL Core will now only change the `audioStreamingState` of all apps to `NOT_AUDIBLE` when `BC.OnEventChanged(PHONE_CALL, active=true)` is sent, leaving each app's `hmiLevel` unchanged. This allows the HMI to start a phone call in the background without leaving the app screen, if desired.
+
+The HMI can still control the `hmiLevel` of the app during a phone call event by sending `BC.OnAppDeactivated(appID)` and `BC.OnAppActivated(appID)` where appropriate.
+
+## HMI API Updates
+
+### Buttons.SubscribeButton
+
+`Buttons.OnButtonSubscription` notification was replaced by `Buttons.SubscribeButton` request and response.
+
+```xml
+<function name="SubscribeButton" messagetype="request">
+        <description>
+            Subscribes to buttons.            
+        </description>
+		
+	    <param name="appID" type="Integer" mandatory="true">
+			<description>The ID of the application requesting this button subscription. </description>
+        </param>
+		
+        <param name="buttonName" type="ButtonName" mandatory="true">
+            <description>Name of the button to subscribe.</description>
+        </param>
+</function>
+
+<function name="SubscribeButton" messagetype="response"> </function>
+```
+
+### Buttons.UnsubscribeButton
+
+
+`Buttons.UnsubscribeButton` request and response were added to allow SDL Core to request that the HMI unsubscribes an application from a specific button.
+
+```
+<function name="UnsubscribeButton" messagetype="request">
+        <description>
+            Unsubscribes from buttons.            
+        </description>
+        
+        <param name="appID" type="Integer" mandatory="true">
+            <description>The ID of the application requesting this button unsubscription. </description>
+        </param>
+        
+        <param name="buttonName" type="ButtonName" mandatory="true">
+            <description>Name of the button to unsubscribe.</description>
+        </param>
+    </function>
+
+<function name="UnsubscribeButton" messagetype="response"></function>
+
+```
+
+### Restructuring OnResetTimeout 
+
+`UI.OnResetTimeout` and `TTS.OnResetTimeout` were removed in place of using a broader RPC, `BasicCommunication.OnResetTimeout`.
+
+This updated `OnResetTimeout` RPC can be used across all interfaces for all request functions.
+
+The parameters in the notification have also changed:
+- The parameter `requestID` is used instead of `appID` to identify which specific request should have its timeout extended.
+- The parameter `methodName` should include the interface name and the RPC. For example: `”TTS.Speak”`.
+- The parameter `resetPeriod` allows the HMI to specify how long Core should delay the application request’s timeout.
+
+
+```
+<interface name="BasicCommunication">
+...
+<function name="OnResetTimeout" messagetype="notification" since="X.Y">
+    <description>
+		HMI must send this notification to SDL for method instance for which timeout needs to be reset
+    </description>	
+    <param name="requestID" type="Integer" mandatory="true">	
+		<description>
+			Id between HMI and SDL which SDL used to send the request for method in question, for which timeout needs to be reset.
+		</description>
+    </param>
+    <param name="methodName" type="String" mandatory="true">
+		<description>
+			Name of the function for which timeout needs to be reset
+		</description>
+    </param>
+    <param name="resetPeriod" type="Integer" minvalue="0" maxvalue="1000000" mandatory="false">
+		<description>
+			Timeout period in milliseconds, for the method for which timeout needs to be reset.
+			If omitted, timeout would be reset by defaultTimeout specified in smartDeviceLink.ini
+		</description>
+    </param>
+</function>
+…
+</interface>
+
+```

--- a/docs/Migrating to Newer SDL Versions/Migrating SDL Core 7.1 to 8.0/index.md
+++ b/docs/Migrating to Newer SDL Versions/Migrating SDL Core 7.1 to 8.0/index.md
@@ -68,8 +68,8 @@ The HMI can still control the `hmiLevel` of the app during a phone call event by
             Subscribes to buttons.            
         </description>
 		
-	    <param name="appID" type="Integer" mandatory="true">
-			<description>The ID of the application requesting this button subscription. </description>
+        <param name="appID" type="Integer" mandatory="true">
+            <description>The ID of the application requesting this button subscription. </description>
         </param>
 		
         <param name="buttonName" type="ButtonName" mandatory="true">

--- a/docs/Overview/index.md
+++ b/docs/Overview/index.md
@@ -20,6 +20,7 @@ Here you will find guides on how to set up SDL Core, integrate an HMI, and how t
 
 - [Migrating SDL Core 6.1 to 7.0](../migrating-to-newer-sdl-versions/migrating-sdl-core-61-to-70/)
 - [Migrating SDL Core 7.0 to 7.1](../migrating-to-newer-sdl-versions/migrating-sdl-core-70-to-71/)
+- [Migrating SDL Core 7.1 to 8.0](../migrating-to-newer-sdl-versions/migrating-sdl-core-71-to-80/)
 
 ### Developer Documentation
 


### PR DESCRIPTION
Added SDL Core Guides for:

- Migrating from SDL Core 7.1.0 to 8.0.0

Updated SDL Core Guides for:
- [[SDL 0205] Avoid Custom button subscription in case HMI incompatibility](https://github.com/smartdevicelink/sdl_core/issues/2789)
- [[SDL 0328] Modernize Ubuntu Support V20 LTS](https://github.com/smartdevicelink/sdl_core/issues/3606)
- Adding Boost Logger to SDL Core