### PR TITLE
SDL Core 8.1.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -90,6 +90,9 @@
                 },
                 {
                     "name": "Migrating SDL Core 7.1 to 8.0"
+                },
+                {
+                    "name": "Migrating SDL Core 8.0 to 8.1"
                 }
             ]
         },

--- a/docs/Feature Documentation/RPC Encryption/index.md
+++ b/docs/Feature Documentation/RPC Encryption/index.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-This guide will cover the basic setup required to enable and utilize RPC Encryption within SDL Core. For more information about the feature, please take a look at the [RPC Encryption Overview Guide](https://smartdevicelink.com/en/guides/sdl-overview-guides/rpc-encryption).
+This guide will cover the basic setup required to enable and utilize RPC Encryption within SDL Core. For more information about the feature, please take a look at the [RPC Encryption Overview Guide](https://smartdevicelink.com/en/guides/sdl-overview-guides/security/rpc-encryption/).
 
 ## Encryption Setup
 

--- a/docs/Feature Documentation/Remote Control/index.md
+++ b/docs/Feature Documentation/Remote Control/index.md
@@ -84,7 +84,7 @@ GetInteriorVehicleData is used to request information about a specific module. T
 If an application sends GetInteriorVehicleData (subscribe=true, moduleType=MODULE1), but the application is already subscribed on MODULE1 module type, SDL will respond with a `WARNINGS` resultCode because of the double subscription.
 !!!
 
-View **GetInteriorVehicleData** in the [RPC Spec](https://github.com/smartdevicelink/rpc_spec#getinteriorvehicledata) or the [HMI Documentation](https://smartdevicelink.com/en/guides/hmi/rc/getinteriorvehicledata)
+View **GetInteriorVehicleData** in the [RPC Spec](https://github.com/smartdevicelink/rpc_spec#getinteriorvehicledata) or the [HMI Documentation](https://smartdevicelink.com/en/docs/hmi/master/rc/getinteriorvehicledata/)
 
 ### OnInteriorVehicleData
 

--- a/docs/Integrating Your HMI/Developing the HMI UI/index.md
+++ b/docs/Integrating Your HMI/Developing the HMI UI/index.md
@@ -33,7 +33,7 @@ When the user selects an application from the app list, a request should be made
 ![App Selection](./assets/activate_deactivate.gif)
 
 !!! NOTE
-The default template for an app should be used if the app has not requested to use a specific template via the `UI.Show.templateConfiguration` parameter or `UI.SetDisplayLayout` RPC (deprecated).
+The default template for an app should be used if the app has not requested to use a specific template via the `UI.Show.templateConfiguration` parameter.
 
 The default template for media apps is `MEDIA`, and the default template for all other apps is `NON-MEDIA`.
 
@@ -146,15 +146,13 @@ Not all HMIs support the ability to detect a button press duration, or different
 
 ## Switching Templates
 
-SDL Core can request the HMI to change an app's template using a `UI.Show` request, or the deprecated RPC `UI.SetDisplayLayout`.
+SDL Core can request the HMI to change an app's template using a `UI.Show` request.
 
 The following graphic demonstrates switching templates while maintaining the same text, buttons, and graphic:
 
 ![Cycle template layouts](./assets/cycling_templates.gif)
 
 In order to specify the template to be displayed, the `UI.Show` request uses the `templateConfiguration` parameter, which includes a string for the requested layout.
-
-For `UI.SetDisplayLayout`, the `displayLayout` string parameter is used for the same purpose.
 
 Using `UI.Show` is the preferred method because the request can be used to change the layout of the screen and the screen contents in a single request. This helps prevent lag and screen flashing when an app wants to change an app template.
 
@@ -283,10 +281,6 @@ OnEventChanged Sequence Diagram
 There are several ways that the HMI should communicate its UI capabilities to SDL Core. When first connecting the HMI to SDL Core, SDL Core will send a `UI.GetCapabilities` request (a similar GetCapabilities request is sent for every interface). The HMI's response should include accurate information relating to its supported display capabilities, audio pass through capabilities, soft button capabilities, and various other system capabilities (See [UI.GetCapabilities](https://smartdevicelink.com/en/docs/hmi/master/ui/getcapabilities/#parameters_1)).
 
 It is likely that the UI capabilities will be different for each template view, therefore it is important for the HMI to send updates about its capabilities to SDL Core. For example, if an app requests a new template configuration, after switching to that view the HMI must send an `OnSystemCapabilityUpdated` notification for `"systemCapabilityType": "DISPLAYS"`.
-
-!!! NOTE
-Even though `UI.SetDisplayLayout` is deprecated, the HMI can still receive requests to change layouts from this RPC from older applications. It is important that the response for `UI.SetDisplayLayout` includes accurate display capabilities for the new layout as well.
-!!!
 
 As an example, if SDL Core requests to change the layout to the `MEDIA` template, the `OnSystemCapabilitiesUpdated` notification parameters may look something like this (taken from the [Generic HMI](https://github.com/smartdevicelink/generic_hmi)):
 ```JSON

--- a/docs/Integrating Your HMI/SDL Core and HMI Communication/index.md
+++ b/docs/Integrating Your HMI/SDL Core and HMI Communication/index.md
@@ -345,7 +345,7 @@ The error object has the following members:
 | :------------- | :------------- |
 | id       | Required to be the same as the value of "id" in the corresponding Request object. If there was an error in detecting the id of the request object, then this property must be null.   |
 | jsonrpc| Must be exactly "2.0"|
-| error | The error field must contain a `code` field with the [result code](https://smartdevicelink.com/en/guides/hmi/common/enums/#result) value that indicates the error type that occurred, a `data` field with the `method` from the original request, and optionally a `message` field containing the string that provides a short description of the error.|
+| error | The error field must contain a `code` field with the [result code](https://smartdevicelink.com/en/docs/hmi/master/common/enums/#result) value that indicates the error type that occurred, a `data` field with the `method` from the original request, and optionally a `message` field containing the string that provides a short description of the error.|
 
 ### Examples
 #### Response with Error

--- a/docs/Migrating to Newer SDL Versions/Migrating SDL Core 8.0 to 8.1/index.md
+++ b/docs/Migrating to Newer SDL Versions/Migrating SDL Core 8.0 to 8.1/index.md
@@ -1,0 +1,81 @@
+# Migrating SDL Core 8.0 to 8.1
+
+## API changes
+
+The 8.1 release had a few changes to the HMI API that will require updates to your SDL Core integration in your head unit.
+
+### Removal of UI.SetDisplayLayout
+
+With the release of SDL Core 8.1, the `UI.SetDisplayLayout` RPC has been removed from the HMI API.
+
+```xml
+...
+-  <function name="SetDisplayLayout" messagetype="request">
+-    <description>This RPC is deprecated. Use Show RPC to change layout.</description>
+-    <param name="displayLayout" type="String" maxlength="500" mandatory="true">
+-      <description>
+-        Predefined or dynamically created screen layout.
+-        Currently only predefined screen layouts are defined.
+-      </description>
+-    </param>
+-    <param name="appID" type="Integer" mandatory="true">
+-      <description>ID of application related to this RPC.</description>
+-    </param>
+-    <param name="dayColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
+-    <param name="nightColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
+-  </function>
+
+-  <function name="SetDisplayLayout" messagetype="response">
+-    <description>This RPC is deprecated. Use Show RPC to change layout.</description>
+-    <param name="displayCapabilities" type="Common.DisplayCapabilities" mandatory="false">
+-      <description>See DisplayCapabilities</description>
+-    </param>
+-    <param name="buttonCapabilities" type="Common.ButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
+-      <description>See ButtonCapabilities</description >
+-    </param>
+-    <param name="softButtonCapabilities" type="Common.SoftButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
+-      <description>If returned, the platform supports on-screen SoftButtons; see SoftButtonCapabilities.</description >
+-    </param>
+-    <param name="presetBankCapabilities" type="Common.PresetBankCapabilities" mandatory="false">
+-      <description>If returned, the platform supports custom on-screen Presets; see PresetBankCapabilities.</description >
+-    </param>
+-  </function>
+...
+```
+
+When an app sends a `SetDisplayLayout` request, SDL now transforms it into a `UI.Show` request (with the `templateConfiguration` parameter set based on the parameters defined in the `SetDisplayLayout` request) and forwards it to the HMI. The `UI.SetDisplayLayout` implementation was also removed from the [SDL HMI](https://github.com/smartdevicelink/sdl_hmi/pull/664) and [Generic HMI](https://github.com/smartdevicelink/generic_hmi/pull/499). However, developers may decide to keep their implementation to support older versions of SDL Core.
+
+### Removal of duplicate parameter from BasicCommunication.OnPutFile
+
+The duplicate parameter `FileName` was removed from the `BasicCommunication.OnPutFile` RPC in the HMI API
+
+```xml
+<function name="OnPutFile" messagetype="notification" >
+      <description>
+        Notification that is sent to HMI when a mobile application uploads a file
+      </description>
+      ...
+-     <param name="FileName" type="String" maxlength="255" mandatory="true">
+-       <description>File reference name.</description>
+-     </param>
+
+      <param name="syncFileName" type="String" maxlength="255" mandatory="true">
+        <description>File reference name.</description>
+      </param>
+      <param name="fileType" type="Common.FileType" mandatory="true">
+          <description>Selected file type.</description>
+      </param>
+...
+```
+
+The parameter was unused. SDL Core uses `syncFileName` in the notification sent to the HMI.
+
+## Core behavior changes
+
+### Reject PROPRIETARY/HTTP SystemRequests when PTU is not in progress
+
+With the release of 8.1, SDL Core will now reject incoming `PROPRIETARY`/`HTTP` SystemRequests when a policy table update (PTU) is not in progress and if an application not selected for the PTU sends the request.
+
+This was identified as a security flaw since it would allow any application to trigger a PTU. For more information please see proposal [0337](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0337-reject-proprietary-http-systemrequests-when-ptu-not-in-progress.md#motivation).
+
+

--- a/docs/Overview/index.md
+++ b/docs/Overview/index.md
@@ -21,6 +21,8 @@ Here you will find guides on how to set up SDL Core, integrate an HMI, and how t
 - [Migrating SDL Core 6.1 to 7.0](../migrating-to-newer-sdl-versions/migrating-sdl-core-61-to-70/)
 - [Migrating SDL Core 7.0 to 7.1](../migrating-to-newer-sdl-versions/migrating-sdl-core-70-to-71/)
 - [Migrating SDL Core 7.1 to 8.0](../migrating-to-newer-sdl-versions/migrating-sdl-core-71-to-80/)
+- [Migrating SDL Core 8.0 to 8.1](../migrating-to-newer-sdl-versions/migrating-sdl-core-80-to-81/)
+
 
 ### Developer Documentation
 


### PR DESCRIPTION
Added SDL Core Guides for:

- Migrating from SDL Core 8.0.0 to 8.1.0

Updated SDL Core Guides for:
- [[SDL 0334] Transform SetDisplayLayout requests into UI.Show for HMIs](https://github.com/smartdevicelink/sdl_core/issues/3706)
- [[SDL 0265] Remove duplicate parameter FileName from HMI RPC BasicCommunication.OnPutFile](https://github.com/smartdevicelink/sdl_core/issues/3153)
- [[SDL 0337] Reject PROPRIETARY/HTTP SystemRequests when PTU is not in progress](https://github.com/smartdevicelink/sdl_core/issues/3715)